### PR TITLE
Bump to latest devtools

### DIFF
--- a/docs/dev_tools.js
+++ b/docs/dev_tools.js
@@ -37,31 +37,6 @@ class DevTools {
       return ret;
     };
 
-    // nerf some oddness
-    Bindings.DeferredTempFile = function() {
-      this._chunks = [];
-      this._file = null;
-    };
-    Bindings.DeferredTempFile.prototype = {
-      write: function(strings) {
-        this._chunks = this._chunks.concat(strings);
-      },
-      remove: function() {
-        this._file = null;
-        this._chunks = [];
-      },
-      finishWriting: function() {
-        this._file = new Blob(this._chunks.filter(Object), {type: 'text/plain'});
-      },
-      read: function(callback) {
-        if (this._file) {
-          const reader = new FileReader();
-          reader.addEventListener('loadend', callback);
-          reader.readAsText(this._file);
-        }
-      }
-
-    };
     // Common.settings is created in a window onload listener
     window.addEventListener('load', _ => {
       Common.settings.createSetting('timelineCaptureNetwork', true).set(true);

--- a/docs/dev_tools.js
+++ b/docs/dev_tools.js
@@ -37,6 +37,15 @@ class DevTools {
       return ret;
     };
 
+    // don't send application errors to console drawer
+    Common.Console.prototype.addMessage = function(text, level, show) {
+      level = level || Common.Console.MessageLevel.Info;
+      const message = new Common.Console.Message(text, level, Date.now(), show || false);
+      this._messages.push(message);
+      // this.dispatchEventToListeners(Common.Console.Events.MessageAdded, message);
+      window.console[level](text);
+    };
+
     // Common.settings is created in a window onload listener
     window.addEventListener('load', _ => {
       Common.settings.createSetting('timelineCaptureNetwork', true).set(true);

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
 
     </div>
     <script src="service-worker.js"></script>
-    <script src="https://chrome-devtools-frontend.appspot.com/serve_file/@311bc2315d4c10f58421416fc85404d9ef696d76/inspector.js" id="devtoolsscript"></script>
+    <script src="https://chrome-devtools-frontend.appspot.com/serve_file/@14fe0c24836876e87295c3bd65f8482cffd3de73/inspector.js" id="devtoolsscript"></script>
     <script src="https://apis.google.com/js/client.js" defer></script>
     <script src="utils.js" defer></script>
     <script src="auth.js" defer></script>


### PR DESCRIPTION
The real implementation of tempfile was updated in https://chromium-review.googlesource.com/c/569119/ so we dont need to nerf it any longer. (but yes your hack was prescient :)

I am also making sure any calls from DevTools to `Common.console.error` do not attempt to open the console drawer. We want that and the Whats New thing to stay very dead. :)