### PR TITLE
Do CORS request with credentials

### DIFF
--- a/docs/utils.js
+++ b/docs/utils.js
@@ -13,6 +13,7 @@ class Utils {
     return new Promise((resolve, reject) => {
       // Use an XHR rather than fetch so we can have progress events
       const xhr = new XMLHttpRequest();
+      xhr.withCredentials = true;
       xhr.open(method, url);
       addRequestHeaders && addRequestHeaders(xhr);
       // show progress only while getting data


### PR DESCRIPTION
## Problem

Our tracing logs are secured with a JWT token. With the current CORS request we can't authenticate ourself.

## Solution

In order to allow us to use this awesome tool we need to make the CORS request with credentials so all cookies are passed along.