### PR TITLE
Allow loadTimelineFromURL to the same domain

### DIFF
--- a/docs/timeline_viewer.js
+++ b/docs/timeline_viewer.js
@@ -264,7 +264,7 @@ class Viewer {
 
     // hosted devtools gets confused
     // if DevTools is requesting a file thats on our origin, we'll redirect it to devtoolsBase
-    if (url && url.origin === URLofViewer.origin) {
+    if (url && url.origin === URLofViewer.origin && (requestedURL !== this.timelineURL)) {
       const relativeurl = url.pathname.replace(URLofViewer.pathname, '').replace(/^\//, '');
       const redirectedURL = new URL(relativeurl, this.devtoolsBase);
       return this._orig_loadResourcePromise(redirectedURL.toString());


### PR DESCRIPTION
Hello,

I would like to use you app to visualize private timelines reports. 

The timeline-viewer and the timelines reports are in the same domain but now it doesn't work fine because the app thinks that is a local resouce and forward the request to the original one.

